### PR TITLE
Don't choose a range unless it includes the entire current range.

### DIFF
--- a/evil-textobj-anyblock.el
+++ b/evil-textobj-anyblock.el
@@ -82,8 +82,8 @@ whether to make an outer or inner textobject."
                            open-block close-block beg end type count outerp)))
                      (when (and block-info
                                 ;; prevent seeking forward behaviour for quotes
-                                (>= (point) (cl-first block-info))
-                                (<= (point) (cl-second block-info)))
+                                (>= beg (cl-first block-info))
+                                (<= end (cl-second block-info)))
                        ;; (append block-info (list open-block close-block))
                        block-info)))
             collect it)


### PR DESCRIPTION
Sometimes when I use `ib` (with the anyblock object bound to "b"), the range shrinks.  Eg. if I repeat `ib` inside this:

([foo bar])

It goes back and forth between being inside the [] and inside the ().  With this change it doesn't select a new region unless it contains the entire previous region, so it doesn't go back to being inside the [] once it's gone further out.
