### PR TITLE
Why is the commented-out code there?

### DIFF
--- a/evil-textobj-anyblock.el
+++ b/evil-textobj-anyblock.el
@@ -107,23 +107,31 @@ blocks."
 
 (defun evil-textobj-anyblock--make-textobj (beg end type count outerp)
   "Helper function for creating both inner and outer text objects."
-  (let ((textobj-info
-         (car (evil-textobj-anyblock--sort-blocks beg end type count outerp))))
-    (if textobj-info
-        textobj-info
-      ;; seek if no surrounding textobj found
-      (let* ( ;; (save-position (point))
-             (seek-block-list (evil-textobj-anyblock--seek-forward))
-             (open-block (cl-first seek-block-list))
-             (close-block (cl-second seek-block-list))
-             ;; need to alter beg and end to get it to work in visual mode
-             (new-beg (if (equal evil-state 'visual)
-                          evil-visual-beginning
-                        (point)))
-             (new-end (save-excursion (right-char) (point))))
-        (when seek-block-list
-          (evil-textobj-anyblock--choose-textobj-method
-           open-block close-block new-beg new-end type count outerp))))))
+  ;;; Why do week seek if there is no surrounding textobj?  This makes me
+  ;;; occasionally go to a sibling node at the top level, when what I really
+  ;;; want to do is just have it be a no-op.  It seems to work perfectly if
+  ;;; I just do textobj-info if it's there, and otherwise simply fail.
+  ;;; (The times it goes to a sibling node is when I have multi-character
+  ;;; delimiters, which is rare but occasionally happens.)
+;  (let ((textobj-info
+;         (car (evil-textobj-anyblock--sort-blocks beg end type count outerp))))
+;    (if textobj-info
+;        textobj-info
+;      ;; seek if no surrounding textobj found
+;      (let* ( ;; (save-position (point))
+;             (seek-block-list (evil-textobj-anyblock--seek-forward))
+;             (open-block (cl-first seek-block-list))
+;             (close-block (cl-second seek-block-list))
+;             ;; need to alter beg and end to get it to work in visual mode
+;             (new-beg (if (equal evil-state 'visual)
+;                          evil-visual-beginning
+;                        (point)))
+;             (new-end (save-excursion (right-char) (point))))
+;        (when seek-block-list
+;          (evil-textobj-anyblock--choose-textobj-method
+;           open-block close-block new-beg new-end type count outerp)))))
+  (car (evil-textobj-anyblock--sort-blocks beg end type count outerp))
+  )
 
 ;;;###autoload (autoload 'evil-textobj-anyblock-inner-block "evil-textobj-anyblock" nil t)
 (evil-define-text-object evil-textobj-anyblock-inner-block


### PR DESCRIPTION
This PR is primarily to ask a question.  It fixes an issue I have, but I also just removed a bunch of code, and maybe that's breaking some feature I don't use.

The issue it causes is that for multi-character delimiters (eg. #| and |# are nestable comment delimiters in Racket) sometimes jump to a sibling node.  For instance:

```
#|this is an &example for #|textobj-anyblock,|#
  demonstrating an issue.|#
(foo bar)
```

where & represents the cursor position.  I type `vib` and the region becomes:

```
#|this is an example for #|&textobj-anyblock,&|#
  demonstrating an issue.|#
(foo bar)
```

This is actually due to a bug in evil, which I've submitted a [PR for](https://bitbucket.org/lyro/evil/pull-requests/75/fix-evil-up-block/diff).  Repeat `vib` and it is correct:

```
#|&this is an example for #|textobj-anyblock,|#
  demonstrating an issue.&|#
(foo bar)
```

But one more repeat is wrong again:

```
#|this is an example for #|textobj-anyblock,|#
  demonstrating an issue.|#
(&foo bar&)
```

This change fixes the issue of going to a sibling node.  It fails if you use it before the nested comment (it works inside the nested comment and after the nested comment) because of the bug in evil, but if you use evil patched with my PR then this change fixes the problem. I'm not sure if it's breaking some other intended behavior.  Was the code I removed trying to work around issues with evil-up-block and such?  Or is there something going on that I'm missing?

This PR just comments out the code with an extra comment on why it seems unnecessary to me.  So if this is something to be merged, that should be removed rather than commented out.  But I want to know if I'm missing anything, first of all.

Thanks,
William
