### PR TITLE
fix issue

### DIFF
--- a/evil-textobj-anyblock.el
+++ b/evil-textobj-anyblock.el
@@ -83,8 +83,9 @@ whether to make an outer or inner textobject."
                      (when (and block-info
                                 ;; prevent seeking forward behaviour for quotes
                                 ;; require a new region to be larder on both sides
-                                (>= (or beg (point)) (cl-first block-info))
-                                (<= (or end (point)) (cl-second block-info)))
+                                (or (and (not beg) (not end))
+                                    (>= beg (cl-first block-info))
+                                    (<= rnd (cl-second block-info))))
                        ;; (append block-info (list open-block close-block))
                        block-info)))
             collect it)


### PR DESCRIPTION
If you have text like `(test (test (test)))` with your cursor on the
left-most closing paren, typing `vib` does nothing while `vi)` makes the
region go over the inside of the inner-most parentheses.  This fixes it
so they behave the same.  Specifically, it relaxes the rule that the new
region must properly contain the old region to when there actually is a
region -- IE `(point)` can be outside of the new region.